### PR TITLE
Move helper conditions from another rule into here

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_bzlmodrio_toolchains",
-    version = "2024-1",
+    version = "2024-1.bcr1",
     compatibility_level = 2024,
 )
 

--- a/conditions/BUILD.bazel
+++ b/conditions/BUILD.bazel
@@ -1,0 +1,100 @@
+# Mimics @bazel_tools/src/conditions:windows
+config_setting(
+    name = "windows",
+    constraint_values = ["@platforms//os:windows"],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows_debug",
+    constraint_values = ["@platforms//os:windows"],
+    values = {
+        "compilation_mode": "dbg",
+    },
+    visibility = ["//visibility:public"],
+)
+
+# Mimics @bazel_tools/src/conditions:windows_arm64
+config_setting(
+    name = "windows_arm64",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    values = {"cpu": "x64_arm64_windows"},
+)
+
+config_setting(
+    name = "windows_arm64_debug",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    values = {
+        "compilation_mode": "dbg",
+        "cpu": "x64_arm64_windows",
+    },
+    visibility = ["//visibility:public"],
+)
+
+# Mimics @bazel_tools/src/conditions:linux_x86_64
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_x86_64_debug",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    values = {
+        "compilation_mode": "dbg",
+    },
+    visibility = ["//visibility:public"],
+)
+
+# Mimics @bazel_tools/src/conditions:darwin
+config_setting(
+    name = "osx",
+    constraint_values = ["@platforms//os:macos"],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "osx_debug",
+    constraint_values = ["@platforms//os:macos"],
+    values = {
+        "compilation_mode": "dbg",
+    },
+    visibility = ["//visibility:public"],
+)
+
+# Custom definitions
+
+# Linux - 64-bit arm
+config_setting(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_arm64_debug",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+    values = {
+        "compilation_mode": "dbg",
+    },
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This moves these commonly used conditions out of a different rule (`rules_bazelrio` which hasn't been migrated to wpilib). That rule is pretty heavyweight and contains several other tooling features not strictly related to toolchain helper utilities.