### PR TITLE
Add system core compiler option

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,7 +50,6 @@ build:raspibookworm32 --platform_suffix=raspibookworm32
 
 # Alias toolchain names to what wpilibsuite uses for CI/Artifact naming
 build:athena --config=roborio
-build:systemcore --config=bookworm64
 build:linuxarm32 --config=raspibookworm32
 build:linuxarm64 --config=bookworm64
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -8,39 +8,44 @@ import .bazelrc-buildbuddy
 build --test_env=LD_LIBRARY_PATH=.
 build --test_env=DYLD_LIBRARY_PATH=.
 
-# Roborio
+# roborio
 build:roborio --platforms=@rules_bzlmodrio_toolchains//platforms/roborio
 build:roborio --build_tag_filters=-no-roborio
 build:roborio --platform_suffix=roborio
 
+# systemcore
+build:systemcore --platforms=@rules_bzlmodrio_toolchains//platforms/systemcore
+build:systemcore --build_tag_filters=-no-systemcore
+build:systemcore --platform_suffix=systemcore
+
 # bullseye32
 build:bullseye32 --platforms=@rules_bzlmodrio_toolchains//platforms/bullseye32
-build:bullseye32 --build_tag_filters=-no-bullseye
+build:bullseye32 --build_tag_filters=-no-bullseye32
 build:bullseye32 --platform_suffix=bullseye32
 
 # bullseye64
 build:bullseye64 --platforms=@rules_bzlmodrio_toolchains//platforms/bullseye64
-build:bullseye64 --build_tag_filters=-no-bullseye
+build:bullseye64 --build_tag_filters=-no-bullseye64
 build:bullseye64 --platform_suffix=bullseye64
 
 # bookworm32
 build:bookworm32 --platforms=@rules_bzlmodrio_toolchains//platforms/bookworm32
-build:bookworm32 --build_tag_filters=-no-bookworm
+build:bookworm32 --build_tag_filters=-no-bookworm32
 build:bookworm32 --platform_suffix=bookworm32
 
 # bookworm64
 build:bookworm64 --platforms=@rules_bzlmodrio_toolchains//platforms/bookworm64
-build:bookworm64 --build_tag_filters=-no-bookworm
+build:bookworm64 --build_tag_filters=-no-bookworm64
 build:bookworm64 --platform_suffix=bookworm64
 
-# rasppi bullseye
+# raspibullseye32
 build:raspibullseye32 --platforms=@rules_bzlmodrio_toolchains//platforms/raspibullseye32
-build:raspibullseye32 --build_tag_filters=-no-raspi
+build:raspibullseye32 --build_tag_filters=-no-raspibullseye32
 build:raspibullseye32 --platform_suffix=raspibullseye32
 
-# rasppi bookworm
+# raspibookworm32
 build:raspibookworm32 --platforms=@rules_bzlmodrio_toolchains//platforms/raspibookworm32
-build:raspibookworm32 --build_tag_filters=-no-raspi
+build:raspibookworm32 --build_tag_filters=-no-raspibookworm32
 build:raspibookworm32 --platform_suffix=raspibookworm32
 
 # Alias toolchain names to what wpilibsuite uses for CI/Artifact naming

--- a/.bazelrc-cc
+++ b/.bazelrc-cc
@@ -40,10 +40,15 @@ build:macos --cxxopt=-Wno-error=deprecated-anon-enum-enum-conversion
 build:macos --cxxopt=-Wno-error=inconsistent-missing-override
 build:macos --cxxopt=-Wno-error=overloaded-virtual
 
-# Roborio
+# roborio
 build:roborio --incompatible_enable_cc_toolchain_resolution
 build:roborio --copt=-std=c++20
 build:roborio --features=compiler_param_file
+
+# systemcore
+build:systemcore --incompatible_enable_cc_toolchain_resolution
+build:systemcore --copt=-std=c++20
+build:systemcore --features=compiler_param_file
 
 # bullseye32
 build:bullseye32 --incompatible_enable_cc_toolchain_resolution
@@ -65,12 +70,12 @@ build:bookworm64 --incompatible_enable_cc_toolchain_resolution
 build:bookworm64 --copt=-std=c++20
 build:bookworm64 --features=compiler_param_file
 
-# rasppi bullseye
+# raspibullseye32
 build:raspibullseye32 --incompatible_enable_cc_toolchain_resolution
 build:raspibullseye32 --copt=-std=c++20
 build:raspibullseye32 --features=compiler_param_file
 
-# rasppi bookworm
+# raspibookworm32
 build:raspibookworm32 --incompatible_enable_cc_toolchain_resolution
 build:raspibookworm32 --copt=-std=c++20
 build:raspibookworm32 --features=compiler_param_file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         - { name: "macos   - systemcore",         os: macos-14,     java_arch: "aarch64", command: "build", config: "--noenable_bzlmod --config=systemcore", bazel_options: "",                                 }
 
         # Build bzlmod, systemcore
-        # - { name: "windows - bzlmod systemcore",  os: windows-2022, java_arch: "x64",     command: "build", config: "--enable_bzlmod --config=systemcore", bazel_options: "--output_user_root=C:\\bazelroot", }
+        - { name: "windows - bzlmod systemcore",  os: windows-2022, java_arch: "x64",     command: "build", config: "--enable_bzlmod --config=systemcore", bazel_options: "--output_user_root=C:\\bazelroot", }
         - { name: "ubuntu  - bzlmod systemcore",  os: ubuntu-22.04, java_arch: "x64",     command: "build", config: "--enable_bzlmod --config=systemcore", bazel_options: "",                                 }
         - { name: "macos   - bzlmod systemcore",  os: macos-14,     java_arch: "aarch64", command: "build", config: "--enable_bzlmod --config=systemcore", bazel_options: "",                                 }
     name: "Build - ${{ matrix.name }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         - { name: "macos   - roborio",         os: macos-14,     java_arch: "aarch64", command: "build", config: "--noenable_bzlmod --config=roborio", bazel_options: "",                                 }
 
         # Build bzlmod, roborio
-        # - { name: "windows - bzlmod roborio",  os: windows-2022, java_arch: "x64",     command: "build", config: "--enable_bzlmod --config=roborio", bazel_options: "--output_user_root=C:\\bazelroot", }
+      # - { name: "windows - bzlmod roborio",  os: windows-2022, java_arch: "x64",     command: "build", config: "--enable_bzlmod --config=roborio", bazel_options: "--output_user_root=C:\\bazelroot", }
         - { name: "ubuntu  - bzlmod roborio",  os: ubuntu-22.04, java_arch: "x64",     command: "build", config: "--enable_bzlmod --config=roborio", bazel_options: "",                                 }
         - { name: "macos   - bzlmod roborio",  os: macos-14,     java_arch: "aarch64", command: "build", config: "--enable_bzlmod --config=roborio", bazel_options: "",                                 }
     name: "Build - ${{ matrix.name }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,42 @@ jobs:
       run: bazel ${{ matrix.bazel_options }} ${{ matrix.command }} //... -k ${{ matrix.config }} --verbose_failures --config=ci
       working-directory: tests
 
+  build_systemcore:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # Build non-bzlmod, systemcore
+        - { name: "windows - systemcore",         os: windows-2022, java_arch: "x64",     command: "build", config: "--noenable_bzlmod --config=systemcore", bazel_options: "--output_user_root=C:\\bazelroot", }
+        - { name: "ubuntu  - systemcore",         os: ubuntu-22.04, java_arch: "x64",     command: "build", config: "--noenable_bzlmod --config=systemcore", bazel_options: "",                                 }
+        - { name: "macos   - systemcore",         os: macos-14,     java_arch: "aarch64", command: "build", config: "--noenable_bzlmod --config=systemcore", bazel_options: "",                                 }
+
+        # Build bzlmod, systemcore
+        # - { name: "windows - bzlmod systemcore",  os: windows-2022, java_arch: "x64",     command: "build", config: "--enable_bzlmod --config=systemcore", bazel_options: "--output_user_root=C:\\bazelroot", }
+        - { name: "ubuntu  - bzlmod systemcore",  os: ubuntu-22.04, java_arch: "x64",     command: "build", config: "--enable_bzlmod --config=systemcore", bazel_options: "",                                 }
+        - { name: "macos   - bzlmod systemcore",  os: macos-14,     java_arch: "aarch64", command: "build", config: "--enable_bzlmod --config=systemcore", bazel_options: "",                                 }
+    name: "Build - ${{ matrix.name }}"
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with: { python-version: '3.11' }
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: 17
+        architecture: ${{ matrix.java_arch }}
+    - id: setup_build_buddy
+      uses: ./.github/actions/setup-build-buddy
+      with:
+        token: ${{ secrets.BUILDBUDDY_API_KEY }}
+    - name: Build and allow failure # TODO Sometimes symlinks don't get created correctly the first time around
+      run: bazel ${{ matrix.bazel_options }} ${{ matrix.command }} //... -k ${{ matrix.config }} --verbose_failures --config=ci || true
+      working-directory: tests
+    - name: Build
+      run: bazel ${{ matrix.bazel_options }} ${{ matrix.command }} //... -k ${{ matrix.config }} --verbose_failures --config=ci
+      working-directory: tests
+
   build_linuxarm32:
     strategy:
       fail-fast: false

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,10 +39,14 @@ use_repo(
     "bazelrio_roborio_toolchain_macos",
     "bazelrio_roborio_toolchain_macosarm",
     "bazelrio_roborio_toolchain_windows",
+    "bazelrio_systemcore_toolchain_linux",
+    "bazelrio_systemcore_toolchain_macos",
+    "bazelrio_systemcore_toolchain_macosarm",
+    "bazelrio_systemcore_toolchain_windows",
 )
 
 sh_configure = use_extension("@rules_bzlmodrio_toolchains//:extensions.bzl", "sh_configure")
-use_repo(sh_configure, "local_bookworm_32", "local_bookworm_64", "local_bullseye_32", "local_bullseye_64", "local_raspi_bookworm_32", "local_raspi_bullseye_32", "local_roborio")
+use_repo(sh_configure, "local_bookworm_32", "local_bookworm_64", "local_bullseye_32", "local_bullseye_64", "local_raspi_bookworm_32", "local_raspi_bullseye_32", "local_roborio", "local_systemcore")
 
 register_toolchains(
     "@local_bookworm_32//:macos",
@@ -66,4 +70,7 @@ register_toolchains(
     "@local_roborio//:macos",
     "@local_roborio//:linux",
     "@local_roborio//:windows",
+    "@local_systemcore//:macos",
+    "@local_systemcore//:linux",
+    "@local_systemcore//:windows",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_bzlmodrio_toolchains",
-    version = "2025-1.bcr1",
+    version = "2025-1.bcr2",
     compatibility_level = 2025,
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,6 +30,9 @@ register_toolchains(
     "@local_roborio//:macos",
     "@local_roborio//:linux",
     "@local_roborio//:windows",
+    "@local_systemcore//:macos",
+    "@local_systemcore//:linux",
+    "@local_systemcore//:windows",
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/constraints/is_systemcore/BUILD.bazel
+++ b/constraints/is_systemcore/BUILD.bazel
@@ -1,0 +1,30 @@
+constraint_setting(
+    name = "is_systemcore",
+    default_constraint_value = ":false",
+)
+
+constraint_value(
+    name = "true",
+    constraint_setting = ":is_systemcore",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "false",
+    constraint_setting = ":is_systemcore",
+)
+
+config_setting(
+    name = "systemcore",
+    constraint_values = [":true"],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "systemcore_debug",
+    constraint_values = [":true"],
+    values = {
+        "compilation_mode": "dbg",
+    },
+    visibility = ["//visibility:public"],
+)

--- a/maven_deps.bzl
+++ b/maven_deps.bzl
@@ -219,6 +219,36 @@ def __setup_toolchains_dependencies(mctx):
         build_file_content = filegroup_all,
     )
 
+    # systemcore
+    maybe(
+        http_archive,
+        "bazelrio_systemcore_toolchain_macosarm",
+        url = "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-arm64-apple-darwin-Toolchain-12.2.0.tgz",
+        sha256 = "e29fa2433cee667d75ff106543d88d3d4154e2f450c79d86d316d5b8015d11e4",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "bazelrio_systemcore_toolchain_macos",
+        url = "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-x86_64-apple-darwin-Toolchain-12.2.0.tgz",
+        sha256 = "34af7c9b601bbce1fe5c5e07f70fe8abd7ed3985cc603dbc12ef7f3d8c2f0b9d",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "bazelrio_systemcore_toolchain_linux",
+        url = "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-x86_64-linux-gnu-Toolchain-12.2.0.tgz",
+        sha256 = "d94005ae516bb43fc85a07ed89cb51bec96ed931ca5c084427f1432a1dbf71e9",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "bazelrio_systemcore_toolchain_windows",
+        url = "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-x86_64-w64-mingw32-Toolchain-12.2.0.zip",
+        sha256 = "50f26a9b0ae595bd536f5b7003a465b04871005cbe57c18e84f657e83df13f4c",
+        build_file_content = filegroup_all,
+    )
+
 def setup_legacy_setup_toolchains_dependencies():
     __setup_toolchains_dependencies(None)
 

--- a/platforms/systemcore/BUILD.bazel
+++ b/platforms/systemcore/BUILD.bazel
@@ -1,0 +1,8 @@
+platform(
+    name = "systemcore",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:armv7",
+        "//constraints/is_systemcore:true",
+    ],
+)

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -50,7 +50,6 @@ build:raspibookworm32 --platform_suffix=raspibookworm32
 
 # Alias toolchain names to what wpilibsuite uses for CI/Artifact naming
 build:athena --config=roborio
-build:systemcore --config=bookworm64
 build:linuxarm32 --config=raspibookworm32
 build:linuxarm64 --config=bookworm64
 

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -8,39 +8,44 @@ import .bazelrc-buildbuddy
 build --test_env=LD_LIBRARY_PATH=.
 build --test_env=DYLD_LIBRARY_PATH=.
 
-# Roborio
+# roborio
 build:roborio --platforms=@rules_bzlmodrio_toolchains//platforms/roborio
 build:roborio --build_tag_filters=-no-roborio
 build:roborio --platform_suffix=roborio
 
+# systemcore
+build:systemcore --platforms=@rules_bzlmodrio_toolchains//platforms/systemcore
+build:systemcore --build_tag_filters=-no-systemcore
+build:systemcore --platform_suffix=systemcore
+
 # bullseye32
 build:bullseye32 --platforms=@rules_bzlmodrio_toolchains//platforms/bullseye32
-build:bullseye32 --build_tag_filters=-no-bullseye
+build:bullseye32 --build_tag_filters=-no-bullseye32
 build:bullseye32 --platform_suffix=bullseye32
 
 # bullseye64
 build:bullseye64 --platforms=@rules_bzlmodrio_toolchains//platforms/bullseye64
-build:bullseye64 --build_tag_filters=-no-bullseye
+build:bullseye64 --build_tag_filters=-no-bullseye64
 build:bullseye64 --platform_suffix=bullseye64
 
 # bookworm32
 build:bookworm32 --platforms=@rules_bzlmodrio_toolchains//platforms/bookworm32
-build:bookworm32 --build_tag_filters=-no-bookworm
+build:bookworm32 --build_tag_filters=-no-bookworm32
 build:bookworm32 --platform_suffix=bookworm32
 
 # bookworm64
 build:bookworm64 --platforms=@rules_bzlmodrio_toolchains//platforms/bookworm64
-build:bookworm64 --build_tag_filters=-no-bookworm
+build:bookworm64 --build_tag_filters=-no-bookworm64
 build:bookworm64 --platform_suffix=bookworm64
 
-# rasppi bullseye
+# raspibullseye32
 build:raspibullseye32 --platforms=@rules_bzlmodrio_toolchains//platforms/raspibullseye32
-build:raspibullseye32 --build_tag_filters=-no-raspi
+build:raspibullseye32 --build_tag_filters=-no-raspibullseye32
 build:raspibullseye32 --platform_suffix=raspibullseye32
 
-# rasppi bookworm
+# raspibookworm32
 build:raspibookworm32 --platforms=@rules_bzlmodrio_toolchains//platforms/raspibookworm32
-build:raspibookworm32 --build_tag_filters=-no-raspi
+build:raspibookworm32 --build_tag_filters=-no-raspibookworm32
 build:raspibookworm32 --platform_suffix=raspibookworm32
 
 # Alias toolchain names to what wpilibsuite uses for CI/Artifact naming

--- a/tests/.bazelrc-cc
+++ b/tests/.bazelrc-cc
@@ -40,10 +40,15 @@ build:macos --cxxopt=-Wno-error=deprecated-anon-enum-enum-conversion
 build:macos --cxxopt=-Wno-error=inconsistent-missing-override
 build:macos --cxxopt=-Wno-error=overloaded-virtual
 
-# Roborio
+# roborio
 build:roborio --incompatible_enable_cc_toolchain_resolution
 build:roborio --copt=-std=c++20
 build:roborio --features=compiler_param_file
+
+# systemcore
+build:systemcore --incompatible_enable_cc_toolchain_resolution
+build:systemcore --copt=-std=c++20
+build:systemcore --features=compiler_param_file
 
 # bullseye32
 build:bullseye32 --incompatible_enable_cc_toolchain_resolution
@@ -65,12 +70,12 @@ build:bookworm64 --incompatible_enable_cc_toolchain_resolution
 build:bookworm64 --copt=-std=c++20
 build:bookworm64 --features=compiler_param_file
 
-# rasppi bullseye
+# raspibullseye32
 build:raspibullseye32 --incompatible_enable_cc_toolchain_resolution
 build:raspibullseye32 --copt=-std=c++20
 build:raspibullseye32 --features=compiler_param_file
 
-# rasppi bookworm
+# raspibookworm32
 build:raspibookworm32 --incompatible_enable_cc_toolchain_resolution
 build:raspibookworm32 --copt=-std=c++20
 build:raspibookworm32 --features=compiler_param_file

--- a/tests/MODULE.bazel.lock
+++ b/tests/MODULE.bazel.lock
@@ -112,7 +112,7 @@
     },
     "@@rules_bzlmodrio_toolchains~//:extensions.bzl%sh_configure": {
       "general": {
-        "bzlTransitiveDigest": "y3VhQ/OweSckH7QhXVVFH8vrtha8h3Qq+zN/iics/uk=",
+        "bzlTransitiveDigest": "FSzzLax1FSAilvZicvnhrjs+SiDm3CUZEJoKp8eiL2s=",
         "usagesDigest": "ZuybEXe3p64B/EeVUmrfjvXGd60Ad75CUCRBRLEbeLs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -208,6 +208,19 @@
               "sysroot_include_folder": "arm-linux-gnueabihf",
               "repo_shortname": "raspi_bullseye_32"
             }
+          },
+          "local_systemcore": {
+            "bzlFile": "@@rules_bzlmodrio_toolchains~//toolchains:configure_cross_compiler.bzl",
+            "ruleClassName": "configure_cross_compiler",
+            "attributes": {
+              "compiler": "systemcore",
+              "bin_subfolder": "bookworm/bin",
+              "bin_prefix": "aarch64-bookworm-linux-gnu-",
+              "sysroot_subfolder": "bookworm/aarch64-linux-gnu/sysroot",
+              "cxx_version": "12",
+              "sysroot_include_folder": "aarch64-linux-gnu",
+              "repo_shortname": "systemcore"
+            }
           }
         },
         "recordedRepoMappingEntries": []
@@ -215,7 +228,7 @@
     },
     "@@rules_bzlmodrio_toolchains~//:maven_deps.bzl%deps": {
       "general": {
-        "bzlTransitiveDigest": "GM0I8AartRlE8RSwTMG7A4F3pL0nggDUq3Cw0mJCCyo=",
+        "bzlTransitiveDigest": "LcB0cBNMQrWFxhP5QvOW1tGUT4VY+4Y43sfw/LuyGrs=",
         "usagesDigest": "URGXGPy9UNtjhZToCcyGfIWzms2OFDbp32AF6EYcOYE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -281,6 +294,15 @@
             "attributes": {
               "url": "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/armhf-bullseye-2025-x86_64-apple-darwin-Toolchain-10.2.0.tgz",
               "sha256": "d46d8191b8ad04494439bf4d14dc599d8531552e56f25dcd7949dc9cf7b0d512",
+              "build_file_content": "filegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "bazelrio_systemcore_toolchain_macosarm": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "url": "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-arm64-apple-darwin-Toolchain-12.2.0.tgz",
+              "sha256": "e29fa2433cee667d75ff106543d88d3d4154e2f450c79d86d316d5b8015d11e4",
               "build_file_content": "filegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n"
             }
           },
@@ -356,6 +378,15 @@
               "build_file_content": "filegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n"
             }
           },
+          "bazelrio_systemcore_toolchain_macos": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "url": "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-x86_64-apple-darwin-Toolchain-12.2.0.tgz",
+              "sha256": "34af7c9b601bbce1fe5c5e07f70fe8abd7ed3985cc603dbc12ef7f3d8c2f0b9d",
+              "build_file_content": "filegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
           "bazelrio_bullseye_32_toolchain_macosarm": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -365,12 +396,30 @@
               "build_file_content": "filegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n"
             }
           },
+          "bazelrio_systemcore_toolchain_windows": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "url": "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-x86_64-w64-mingw32-Toolchain-12.2.0.zip",
+              "sha256": "50f26a9b0ae595bd536f5b7003a465b04871005cbe57c18e84f657e83df13f4c",
+              "build_file_content": "filegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
           "bazelrio_bullseye_64_toolchain_windows": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
             "attributes": {
               "url": "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bullseye-2025-x86_64-w64-mingw32-Toolchain-10.2.0.zip",
               "sha256": "d978c2baa757571b3cb413844f3fa26b779259a4f8a680fb2fb872a13c8618b3",
+              "build_file_content": "filegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "bazelrio_systemcore_toolchain_linux": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "url": "https://github.com/wpilibsuite/opensdk/releases/download/v2025-1/arm64-bookworm-2025-x86_64-linux-gnu-Toolchain-12.2.0.tgz",
+              "sha256": "d94005ae516bb43fc85a07ed89cb51bec96ed931ca5c084427f1432a1dbf71e9",
               "build_file_content": "filegroup(\n    name = \"all\",\n    srcs = glob([\"**\"]),\n    visibility = [\"//visibility:public\"],\n)\n"
             }
           },

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -43,6 +43,9 @@ register_toolchains(
     "@local_roborio//:macos",
     "@local_roborio//:linux",
     "@local_roborio//:windows",
+    "@local_systemcore//:macos",
+    "@local_systemcore//:linux",
+    "@local_systemcore//:windows",
 )
 
 # Styleguide

--- a/toolchains/load_toolchains.bzl
+++ b/toolchains/load_toolchains.bzl
@@ -71,3 +71,13 @@ def load_toolchains():
         sysroot_include_folder = "arm-nilrt-linux-gnueabi",
         repo_shortname = "roborio",
     )
+    configure_cross_compiler(
+        name = "local_systemcore",
+        compiler = "systemcore",
+        bin_subfolder = "bookworm/bin",
+        bin_prefix = "aarch64-bookworm-linux-gnu-",
+        sysroot_subfolder = "bookworm/aarch64-linux-gnu/sysroot",
+        cxx_version = "12",
+        sysroot_include_folder = "aarch64-linux-gnu",
+        repo_shortname = "systemcore",
+    )


### PR DESCRIPTION
At the moment it is functionally the same as bookworm64, but can be used and switch'd on by `--config=systemcore`