### PR TITLE
Make platform constraints more flexible

### DIFF
--- a/constraints/combined/BUILD.bazel
+++ b/constraints/combined/BUILD.bazel
@@ -17,16 +17,14 @@ selects.config_setting_group(
 selects.config_setting_group(
     name = "is_unix",
     match_any = [
-        ":is_cross_compiler",
-        "@bazel_tools//src/conditions:darwin",
-        "@bazel_tools//src/conditions:linux_x86_64",
+        "@platforms//os:macos",
+        "@platforms//os:linux",
     ],
 )
 
 selects.config_setting_group(
     name = "is_linux",
     match_any = [
-        ":is_cross_compiler",
-        "@bazel_tools//src/conditions:linux_x86_64",
+        "@platforms//os:linux",
     ],
 )


### PR DESCRIPTION
I've got toolchains for yocto based linux distributions which are very much linux and unix, but don't match the constraints here.  I want to be able to build network tables for them.  Really, the goal of these is to detect linux, not the particular blessed variants of linux, so say that in the constraints.