### PR TITLE
Properly mark 64 bit platforms as 64 bits

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.9")
-bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 
 deps = use_extension("//:maven_deps.bzl", "deps")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4,40 +4,56 @@
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/abseil-cpp/20211102.0/source.json": "7e3a9adf473e9af076ae485ed649d5641ad50ec5c11718103f34de03170d94ad",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/abseil-cpp/20230802.0.bcr.1/source.json": "14892cc698e02ffedf4967546e6bedb7245015906888d3465fcf27c90a26da10",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/apple_support/1.5.0/source.json": "eb98a7627c0bc486b57f598ad8da50f6625d974c8f723e9ea71bd39f709c9862",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_features/1.11.0/source.json": "c9320aa53cd1c441d24bd6b716da087ad7e4ff0d9742a9884587596edfe53015",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_features/1.19.0/source.json": "d7bf14517c1b25b9d9c580b0f8795fceeae08a7590f507b76aace528e941375d",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_skylib/1.6.1/source.json": "082ed5f9837901fada8c68c2f3ddc958bb22b6d654f71dd73f3df30d45d4b749",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/googletest/1.11.0/source.json": "c73d9ef4268c91bd0c1cd88f1f9dfa08e814b1dbe89b5f594a9f08ba0244d206",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/googletest/1.14.0/source.json": "2478949479000fdd7de9a3d0107ba2c85bb5f961c3ecb1aa448f52549ce310b5",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/platforms/0.0.9/source.json": "cd74d854bf16a9e002fb2ca7b1a421f4403cda29f824a765acd3a8c56f8d43e6",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/protobuf/21.7/source.json": "bbe500720421e582ff2d18b0802464205138c06056f443184de39fbb8187b09b",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/protobuf/27.0/source.json": "1acf3d080c728d42f423fde5422fd0a1a24f44c15908124ce12363a253384193",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_cc/0.0.9/source.json": "1f1ba6fea244b616de4a554a0f4983c91a9301640c8fe0dd1d410254115c8430",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_java/7.6.5/MODULE.bazel": "481164be5e02e4cab6e77a36927683263be56b7e36fef918b458d7a8a1ebadb1",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_java/7.6.5/source.json": "a805b889531d1690e3c72a7a7e47a870d00323186a9904b36af83aa3d053ee8d",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_jvm_external/4.4.2/source.json": "a075731e1b46bc8425098512d038d416e966ab19684a10a34f4741295642fc35",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_jvm_external/5.1/source.json": "5abb45cc9beb27b77aec6a65a11855ef2b55d95dfdc358e9f312b78ae0ba32d5",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_license/0.0.7/source.json": "355cc5737a0f294e560d52b1b7a6492d4fff2caf0bef1a315df5a298fca2d34a",
@@ -51,9 +67,9 @@
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_python/0.22.1/source.json": "57226905e783bae7c37c2dd662be078728e48fa28ee4324a7eabcafb5a43d014",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/stardoc/0.5.1/source.json": "a96f95e02123320aa015b956f29c00cb818fa891ef823d55148e1a362caacf29",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/stardoc/0.5.3/source.json": "cd53fe968dc8cd98197c052db3db6d82562960c87b61e7a90ee96f8e4e0dda97",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
-    "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/upb/0.0.0-20220923-a547704/source.json": "f1ef7d3f9e0e26d4b23d1c39b5f5de71f584dd7d1b4ef83d9bbba6ec7a6a6459",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://raw.githubusercontent.com/pjreiniger/bazel-central-registry/bzlmodrio/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
@@ -63,8 +79,8 @@
   "moduleExtensions": {
     "//:extensions.bzl%sh_configure": {
       "general": {
-        "bzlTransitiveDigest": "j4O0iFZXZn73f671MC8nnNxQjAgGlUpgGlxBz+nI3Ks=",
-        "usagesDigest": "iTn01F7otwYUcckrjfHq2PXjv3tqQ+euV6z5fTndBm4=",
+        "bzlTransitiveDigest": "UQQEHSqtvoKZc++DvYbo6u0Y75TF6P0OS9AqYiouYIQ=",
+        "usagesDigest": "FVzUmNZiuDmVY4f7CPOqXyh3+aF0WwWMyY73VdUzlPM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -78,6 +94,7 @@
               "bin_prefix": "aarch64-bullseye-linux-gnu-",
               "sysroot_subfolder": "bullseye/aarch64-linux-gnu/sysroot",
               "cxx_version": "10",
+              "target_cpu": "armv8a",
               "sysroot_include_folder": "aarch64-linux-gnu",
               "repo_shortname": "bullseye_64"
             }
@@ -88,9 +105,10 @@
             "attributes": {
               "compiler": "roborio",
               "bin_subfolder": "roborio-academic/bin",
-              "bin_prefix": "arm-frc2024-linux-gnueabi-",
+              "bin_prefix": "arm-frc2025-linux-gnueabi-",
               "sysroot_subfolder": "roborio-academic/arm-nilrt-linux-gnueabi/sysroot",
               "cxx_version": "12",
+              "target_cpu": "armv7",
               "sysroot_include_folder": "arm-nilrt-linux-gnueabi",
               "repo_shortname": "roborio"
             }
@@ -104,21 +122,79 @@
               "bin_prefix": "armv7-bullseye-linux-gnueabihf-",
               "sysroot_subfolder": "bullseye/arm-linux-gnueabihf/sysroot",
               "cxx_version": "10",
+              "target_cpu": "armv7",
               "sysroot_include_folder": "arm-linux-gnueabihf",
               "repo_shortname": "bullseye_32"
             }
           },
-          "local_raspi_32": {
+          "local_raspi_bookworm_32": {
             "bzlFile": "@@//toolchains:configure_cross_compiler.bzl",
             "ruleClassName": "configure_cross_compiler",
             "attributes": {
-              "compiler": "raspi-32",
+              "compiler": "raspi-bookworm-32",
+              "bin_subfolder": "raspi-bookworm/bin",
+              "bin_prefix": "armv6-bookworm-linux-gnueabihf-",
+              "sysroot_subfolder": "raspi-bookworm/arm-linux-gnueabihf/sysroot",
+              "cxx_version": "12",
+              "target_cpu": "armv7",
+              "sysroot_include_folder": "arm-linux-gnueabihf",
+              "repo_shortname": "raspi_bookworm_32"
+            }
+          },
+          "local_bookworm_32": {
+            "bzlFile": "@@//toolchains:configure_cross_compiler.bzl",
+            "ruleClassName": "configure_cross_compiler",
+            "attributes": {
+              "compiler": "bookworm-32",
+              "bin_subfolder": "bookworm/bin",
+              "bin_prefix": "armv7-bookworm-linux-gnueabihf-",
+              "sysroot_subfolder": "bookworm/arm-linux-gnueabihf/sysroot",
+              "cxx_version": "12",
+              "target_cpu": "armv7",
+              "sysroot_include_folder": "arm-linux-gnueabihf",
+              "repo_shortname": "bookworm_32"
+            }
+          },
+          "local_bookworm_64": {
+            "bzlFile": "@@//toolchains:configure_cross_compiler.bzl",
+            "ruleClassName": "configure_cross_compiler",
+            "attributes": {
+              "compiler": "bookworm-64",
+              "bin_subfolder": "bookworm/bin",
+              "bin_prefix": "aarch64-bookworm-linux-gnu-",
+              "sysroot_subfolder": "bookworm/aarch64-linux-gnu/sysroot",
+              "cxx_version": "12",
+              "target_cpu": "armv8a",
+              "sysroot_include_folder": "aarch64-linux-gnu",
+              "repo_shortname": "bookworm_64"
+            }
+          },
+          "local_raspi_bullseye_32": {
+            "bzlFile": "@@//toolchains:configure_cross_compiler.bzl",
+            "ruleClassName": "configure_cross_compiler",
+            "attributes": {
+              "compiler": "raspi-bullseye-32",
               "bin_subfolder": "raspi-bullseye/bin",
               "bin_prefix": "armv6-bullseye-linux-gnueabihf-",
               "sysroot_subfolder": "raspi-bullseye/arm-linux-gnueabihf/sysroot",
               "cxx_version": "10",
+              "target_cpu": "armv7",
               "sysroot_include_folder": "arm-linux-gnueabihf",
-              "repo_shortname": "raspi_32"
+              "repo_shortname": "raspi_bullseye_32"
+            }
+          },
+          "local_systemcore": {
+            "bzlFile": "@@//toolchains:configure_cross_compiler.bzl",
+            "ruleClassName": "configure_cross_compiler",
+            "attributes": {
+              "compiler": "systemcore",
+              "bin_subfolder": "bookworm/bin",
+              "bin_prefix": "aarch64-bookworm-linux-gnu-",
+              "sysroot_subfolder": "bookworm/aarch64-linux-gnu/sysroot",
+              "cxx_version": "12",
+              "target_cpu": "armv8a",
+              "sysroot_include_folder": "aarch64-linux-gnu",
+              "repo_shortname": "systemcore"
             }
           }
         },
@@ -156,7 +232,7 @@
     "@@platforms//host:extension.bzl%host_platform": {
       "general": {
         "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "meSzxn3DUCcYEhq4HQwExWkWtU4EjriRBQLsZN+Q0SU=",
+        "usagesDigest": "V1R2Y2oMxKNfx2WCWpSCaUV1WefW1o8HZGm3v1vHgY4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,25 @@
 workspace(name = "rules_bzlmodrio_toolchains")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_cc",
+    sha256 = "712d77868b3152dd618c4d64faaddefcc5965f90f5de6e6dd1d5ddcd0be82d42",
+    strip_prefix = "rules_cc-0.1.1",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz"],
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5",
+    strip_prefix = "protobuf-30.2",
+    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v30.2.tar.gz",
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 load("@rules_bzlmodrio_toolchains//:maven_deps.bzl", "setup_legacy_setup_toolchains_dependencies")
 
 setup_legacy_setup_toolchains_dependencies()
@@ -34,8 +54,6 @@ register_toolchains(
     "@local_systemcore//:linux",
     "@local_systemcore//:windows",
 )
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_skylib",

--- a/platforms/bookworm64/BUILD.bazel
+++ b/platforms/bookworm64/BUILD.bazel
@@ -2,7 +2,7 @@ platform(
     name = "bookworm64",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:armv7",
+        "@platforms//cpu:arm64",
         "//constraints/is_bookworm64:true",
     ],
 )

--- a/platforms/bullseye64/BUILD.bazel
+++ b/platforms/bullseye64/BUILD.bazel
@@ -2,7 +2,7 @@ platform(
     name = "bullseye64",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:armv7",
+        "@platforms//cpu:arm64",
         "//constraints/is_bullseye64:true",
     ],
 )

--- a/platforms/systemcore/BUILD.bazel
+++ b/platforms/systemcore/BUILD.bazel
@@ -2,7 +2,7 @@ platform(
     name = "systemcore",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:armv7",
+        "@platforms//cpu:arm64",
         "//constraints/is_systemcore:true",
     ],
 )

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -5,4 +5,4 @@ local_path_override(
 )
 
 bazel_dep(name = "googletest", version = "1.14.0")
-bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -1,5 +1,12 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+http_archive(
+    name = "rules_cc",
+    sha256 = "712d77868b3152dd618c4d64faaddefcc5965f90f5de6e6dd1d5ddcd0be82d42",
+    strip_prefix = "rules_cc-0.1.1",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz"],
+)
+
 local_repository(
     name = "rules_bzlmodrio_toolchains",
     path = "..",
@@ -62,6 +69,10 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.30.0/rules_python-0.30.0.tar.gz",
 )
 
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
 load("@rules_wpiformat//dependencies:load_rule_dependencies.bzl", "load_wpiformat_rule_dependencies")
 
 load_wpiformat_rule_dependencies()
@@ -77,3 +88,22 @@ load_wpiformat_dependencies()
 load("@rules_wpiformat_pip//:requirements.bzl", "install_deps")
 
 install_deps()
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5",
+    strip_prefix = "protobuf-30.2",
+    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v30.2.tar.gz",
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
+
+rules_java_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
+
+rules_java_toolchains()

--- a/toolchains/configure_cross_compiler.bzl
+++ b/toolchains/configure_cross_compiler.bzl
@@ -48,6 +48,7 @@ def configure_cross_compiler_impl(repository_ctx):
     compiler_workspace = Label("@" + substitutions["{compiler_repo}"]).workspace_name
     substitutions["{actual_compiler_path}"] = compiler_workspace
     substitutions["{target_cpu}"] = repository_ctx.attr.target_cpu
+    substitutions["{target_system_name}"] = repository_ctx.attr.target_system_name
 
     for binary in BINARIES:
         bin_substitution = dict(substitutions)
@@ -83,5 +84,6 @@ configure_cross_compiler = repository_rule(
         "sysroot_include_folder": attr.string(mandatory = True),
         "sysroot_subfolder": attr.string(mandatory = True),
         "target_cpu": attr.string(mandatory = True),
+        "target_system_name": attr.string(mandatory = True),
     },
 )

--- a/toolchains/configure_cross_compiler.bzl
+++ b/toolchains/configure_cross_compiler.bzl
@@ -47,6 +47,7 @@ def configure_cross_compiler_impl(repository_ctx):
 
     compiler_workspace = Label("@" + substitutions["{compiler_repo}"]).workspace_name
     substitutions["{actual_compiler_path}"] = compiler_workspace
+    substitutions["{target_cpu}"] = repository_ctx.attr.target_cpu
 
     for binary in BINARIES:
         bin_substitution = dict(substitutions)
@@ -81,5 +82,6 @@ configure_cross_compiler = repository_rule(
         "repo_shortname": attr.string(mandatory = True),
         "sysroot_include_folder": attr.string(mandatory = True),
         "sysroot_subfolder": attr.string(mandatory = True),
+        "target_cpu": attr.string(mandatory = True),
     },
 )

--- a/toolchains/cross_compiler/BUILD.tpl
+++ b/toolchains/cross_compiler/BUILD.tpl
@@ -1,5 +1,5 @@
 load(":cc-toolchain-config.bzl", "cc_toolchain_config")
-tag = "armv7"
+tag = "{target_cpu}"
 
 cc_toolchain_config_name = "cc-toolchain_config-{}".format(tag)
 
@@ -25,6 +25,7 @@ cc_toolchain_config(
     toolchain_identifier = toolchain_name,
     wrapper_extension = "{wrapper_extension}",
     target_cpu = "{target_cpu}",
+    target_system_name = "{target_system_name}",
     cxx_builtin_include_directories=cxx_builtin_include_directories
 )
 

--- a/toolchains/cross_compiler/BUILD.tpl
+++ b/toolchains/cross_compiler/BUILD.tpl
@@ -24,6 +24,7 @@ cc_toolchain_config(
     name = cc_toolchain_config_name,
     toolchain_identifier = toolchain_name,
     wrapper_extension = "{wrapper_extension}",
+    target_cpu = "{target_cpu}",
     cxx_builtin_include_directories=cxx_builtin_include_directories
 )
 

--- a/toolchains/cross_compiler/cc-toolchain-config.bzl
+++ b/toolchains/cross_compiler/cc-toolchain-config.bzl
@@ -173,7 +173,7 @@ def _impl(ctx):
         features = features,
         toolchain_identifier = ctx.attr.toolchain_identifier,
         host_system_name = "local",
-        target_system_name = "arm-frc2023-linux-gnueabi",
+        target_system_name = ctx.attr.target_system_name,
         target_cpu = ctx.attr.target_cpu,
         target_libc = "glibc-2.24",
         cc_target_os = "linux",
@@ -189,6 +189,7 @@ cc_toolchain_config = rule(
     attrs = {
         "cxx_builtin_include_directories": attr.string_list(mandatory = True),
         "target_cpu": attr.string(mandatory = True),
+        "target_system_name": attr.string(mandatory = True),
         "toolchain_identifier": attr.string(mandatory = True),
         "wrapper_extension": attr.string(mandatory = True),
     },

--- a/toolchains/cross_compiler/cc-toolchain-config.bzl
+++ b/toolchains/cross_compiler/cc-toolchain-config.bzl
@@ -6,6 +6,7 @@ load(
     "flag_set",
     "tool_path",
 )
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 
 def _impl(ctx):
     # Alias for readability
@@ -173,10 +174,10 @@ def _impl(ctx):
         toolchain_identifier = ctx.attr.toolchain_identifier,
         host_system_name = "local",
         target_system_name = "arm-frc2023-linux-gnueabi",
-        target_cpu = "armv7",
+        target_cpu = ctx.attr.target_cpu,
         target_libc = "glibc-2.24",
         cc_target_os = "linux",
-        compiler = "gcc-12.1.0",
+        compiler = "gcc",
         abi_version = "gcc-12.1.0",
         abi_libc_version = "glibc-2.24",
         tool_paths = tool_paths,
@@ -187,6 +188,7 @@ def _impl(ctx):
 cc_toolchain_config = rule(
     attrs = {
         "cxx_builtin_include_directories": attr.string_list(mandatory = True),
+        "target_cpu": attr.string(mandatory = True),
         "toolchain_identifier": attr.string(mandatory = True),
         "wrapper_extension": attr.string(mandatory = True),
     },

--- a/toolchains/load_toolchains.bzl
+++ b/toolchains/load_toolchains.bzl
@@ -8,6 +8,7 @@ def load_toolchains():
         bin_prefix = "armv7-bookworm-linux-gnueabihf-",
         sysroot_subfolder = "bookworm/arm-linux-gnueabihf/sysroot",
         cxx_version = "12",
+        target_cpu = "armv7",
         sysroot_include_folder = "arm-linux-gnueabihf",
         repo_shortname = "bookworm_32",
     )
@@ -18,6 +19,7 @@ def load_toolchains():
         bin_prefix = "aarch64-bookworm-linux-gnu-",
         sysroot_subfolder = "bookworm/aarch64-linux-gnu/sysroot",
         cxx_version = "12",
+        target_cpu = "armv8a",
         sysroot_include_folder = "aarch64-linux-gnu",
         repo_shortname = "bookworm_64",
     )
@@ -28,6 +30,7 @@ def load_toolchains():
         bin_prefix = "armv7-bullseye-linux-gnueabihf-",
         sysroot_subfolder = "bullseye/arm-linux-gnueabihf/sysroot",
         cxx_version = "10",
+        target_cpu = "armv7",
         sysroot_include_folder = "arm-linux-gnueabihf",
         repo_shortname = "bullseye_32",
     )
@@ -38,6 +41,7 @@ def load_toolchains():
         bin_prefix = "aarch64-bullseye-linux-gnu-",
         sysroot_subfolder = "bullseye/aarch64-linux-gnu/sysroot",
         cxx_version = "10",
+        target_cpu = "armv8a",
         sysroot_include_folder = "aarch64-linux-gnu",
         repo_shortname = "bullseye_64",
     )
@@ -48,6 +52,7 @@ def load_toolchains():
         bin_prefix = "armv6-bookworm-linux-gnueabihf-",
         sysroot_subfolder = "raspi-bookworm/arm-linux-gnueabihf/sysroot",
         cxx_version = "12",
+        target_cpu = "armv7",
         sysroot_include_folder = "arm-linux-gnueabihf",
         repo_shortname = "raspi_bookworm_32",
     )
@@ -58,6 +63,7 @@ def load_toolchains():
         bin_prefix = "armv6-bullseye-linux-gnueabihf-",
         sysroot_subfolder = "raspi-bullseye/arm-linux-gnueabihf/sysroot",
         cxx_version = "10",
+        target_cpu = "armv7",
         sysroot_include_folder = "arm-linux-gnueabihf",
         repo_shortname = "raspi_bullseye_32",
     )
@@ -68,6 +74,7 @@ def load_toolchains():
         bin_prefix = "arm-frc2025-linux-gnueabi-",
         sysroot_subfolder = "roborio-academic/arm-nilrt-linux-gnueabi/sysroot",
         cxx_version = "12",
+        target_cpu = "armv7",
         sysroot_include_folder = "arm-nilrt-linux-gnueabi",
         repo_shortname = "roborio",
     )
@@ -78,6 +85,7 @@ def load_toolchains():
         bin_prefix = "aarch64-bookworm-linux-gnu-",
         sysroot_subfolder = "bookworm/aarch64-linux-gnu/sysroot",
         cxx_version = "12",
+        target_cpu = "armv8a",
         sysroot_include_folder = "aarch64-linux-gnu",
         repo_shortname = "systemcore",
     )

--- a/toolchains/load_toolchains.bzl
+++ b/toolchains/load_toolchains.bzl
@@ -9,6 +9,7 @@ def load_toolchains():
         sysroot_subfolder = "bookworm/arm-linux-gnueabihf/sysroot",
         cxx_version = "12",
         target_cpu = "armv7",
+        target_system_name = "arm-linux-gnueabihf",
         sysroot_include_folder = "arm-linux-gnueabihf",
         repo_shortname = "bookworm_32",
     )
@@ -20,6 +21,7 @@ def load_toolchains():
         sysroot_subfolder = "bookworm/aarch64-linux-gnu/sysroot",
         cxx_version = "12",
         target_cpu = "armv8a",
+        target_system_name = "aarch64-linux-gnu",
         sysroot_include_folder = "aarch64-linux-gnu",
         repo_shortname = "bookworm_64",
     )
@@ -31,6 +33,7 @@ def load_toolchains():
         sysroot_subfolder = "bullseye/arm-linux-gnueabihf/sysroot",
         cxx_version = "10",
         target_cpu = "armv7",
+        target_system_name = "arm-linux-gnueabihf",
         sysroot_include_folder = "arm-linux-gnueabihf",
         repo_shortname = "bullseye_32",
     )
@@ -42,6 +45,7 @@ def load_toolchains():
         sysroot_subfolder = "bullseye/aarch64-linux-gnu/sysroot",
         cxx_version = "10",
         target_cpu = "armv8a",
+        target_system_name = "aarch64-linux-gnu",
         sysroot_include_folder = "aarch64-linux-gnu",
         repo_shortname = "bullseye_64",
     )
@@ -53,6 +57,7 @@ def load_toolchains():
         sysroot_subfolder = "raspi-bookworm/arm-linux-gnueabihf/sysroot",
         cxx_version = "12",
         target_cpu = "armv7",
+        target_system_name = "arm-linux-gnueabihf",
         sysroot_include_folder = "arm-linux-gnueabihf",
         repo_shortname = "raspi_bookworm_32",
     )
@@ -64,6 +69,7 @@ def load_toolchains():
         sysroot_subfolder = "raspi-bullseye/arm-linux-gnueabihf/sysroot",
         cxx_version = "10",
         target_cpu = "armv7",
+        target_system_name = "arm-linux-gnueabihf",
         sysroot_include_folder = "arm-linux-gnueabihf",
         repo_shortname = "raspi_bullseye_32",
     )
@@ -75,6 +81,7 @@ def load_toolchains():
         sysroot_subfolder = "roborio-academic/arm-nilrt-linux-gnueabi/sysroot",
         cxx_version = "12",
         target_cpu = "armv7",
+        target_system_name = "arm-nilrt-linux-gnueabi",
         sysroot_include_folder = "arm-nilrt-linux-gnueabi",
         repo_shortname = "roborio",
     )
@@ -86,6 +93,7 @@ def load_toolchains():
         sysroot_subfolder = "bookworm/aarch64-linux-gnu/sysroot",
         cxx_version = "12",
         target_cpu = "armv8a",
+        target_system_name = "aarch64-linux-gnu",
         sysroot_include_folder = "aarch64-linux-gnu",
         repo_shortname = "systemcore",
     )


### PR DESCRIPTION
The bazel ecosystem expects @platforms//cpu:arm64 for 64 bit arm platforms.  Fix that, and some other toolchain properties so that selects in other code resolve correctly.