### PR TITLE
Make all platform definitions public

### DIFF
--- a/platforms/bookworm32/BUILD.bazel
+++ b/platforms/bookworm32/BUILD.bazel
@@ -5,4 +5,5 @@ platform(
         "@platforms//cpu:armv7",
         "//constraints/is_bookworm32:true",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/platforms/bookworm64/BUILD.bazel
+++ b/platforms/bookworm64/BUILD.bazel
@@ -5,4 +5,5 @@ platform(
         "@platforms//cpu:arm64",
         "//constraints/is_bookworm64:true",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/platforms/bullseye32/BUILD.bazel
+++ b/platforms/bullseye32/BUILD.bazel
@@ -5,4 +5,5 @@ platform(
         "@platforms//cpu:armv7",
         "//constraints/is_bullseye32:true",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/platforms/bullseye64/BUILD.bazel
+++ b/platforms/bullseye64/BUILD.bazel
@@ -5,4 +5,5 @@ platform(
         "@platforms//cpu:arm64",
         "//constraints/is_bullseye64:true",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/platforms/raspibookworm32/BUILD.bazel
+++ b/platforms/raspibookworm32/BUILD.bazel
@@ -5,4 +5,5 @@ platform(
         "@platforms//cpu:armv7",
         "//constraints/is_raspibookworm32:true",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/platforms/raspibullseye32/BUILD.bazel
+++ b/platforms/raspibullseye32/BUILD.bazel
@@ -5,4 +5,5 @@ platform(
         "@platforms//cpu:armv7",
         "//constraints/is_raspibullseye32:true",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/platforms/roborio/BUILD.bazel
+++ b/platforms/roborio/BUILD.bazel
@@ -5,4 +5,5 @@ platform(
         "@platforms//cpu:armv7",
         "//constraints/is_roborio:true",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/platforms/systemcore/BUILD.bazel
+++ b/platforms/systemcore/BUILD.bazel
@@ -5,4 +5,5 @@ platform(
         "@platforms//cpu:arm64",
         "//constraints/is_systemcore:true",
     ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
It is really hard to trigger transitions, or other changes without the platform being public.  There is no need to make it private, so just do it.