### PR TITLE
Make toolchain selfcontained

### DIFF
--- a/toolchains/cross_compiler/cc-toolchain-config.bzl
+++ b/toolchains/cross_compiler/cc-toolchain-config.bzl
@@ -20,6 +20,12 @@ def _impl(ctx):
         ACTION_NAMES.cpp_link_nodeps_dynamic_library,
     ]
 
+    lto_index_actions = [
+        ACTION_NAMES.lto_index_for_executable,
+        ACTION_NAMES.lto_index_for_dynamic_library,
+        ACTION_NAMES.lto_index_for_nodeps_dynamic_library,
+    ]
+
     all_compile_actions = [
         ACTION_NAMES.c_compile,
         ACTION_NAMES.cpp_compile,
@@ -86,7 +92,7 @@ def _impl(ctx):
         enabled = True,
         flag_sets = [
             flag_set(
-                actions = all_link_actions,
+                actions = all_link_actions + lto_index_actions,
                 flag_groups = ([
                     flag_group(
                         flags = ([
@@ -98,6 +104,9 @@ def _impl(ctx):
                             "-lstdc++",
                             "-lm",
                             "-fno-canonical-system-headers",
+                            "-rdynamic",
+                            "-ldl",
+                            "-Wl,-rpath,'$ORIGIN'",
                         ],
                     ),
                 ]),
@@ -137,6 +146,8 @@ def _impl(ctx):
                             "-fstack-protector",
                             "-Wall",
                             "-fno-omit-frame-pointer",
+                            "-Wextra",
+                            "-Werror",
                         ],
                     ),
                 ]),
@@ -175,13 +186,36 @@ def _impl(ctx):
             ),
             flag_set(
                 actions = [ACTION_NAMES.c_compile],
-                flag_groups = [],
+                flag_groups = ([
+                    flag_group(
+                        flags = [
+                            "-Wformat=2",
+                            "-pedantic",
+                            "-DAUSTIN_TOOLCHAIN",
+                            "-Wno-psabi",
+                            "-Wno-unused-parameter",
+                            "-fPIC",
+                            "-pthread",
+                        ],
+                    ),
+                ]),
             ),
             flag_set(
                 actions = all_cpp_compile_actions + [ACTION_NAMES.lto_backend],
                 flag_groups = ([
                     flag_group(
-                        flags = ["-std=c++20"],
+                        flags = [
+                            "-std=c++20",
+                            "-Wno-error=deprecated-declarations",
+                            "-Wno-deprecated-enum-enum-conversion",
+                            "-Wformat=2",
+                            "-pedantic",
+                            "-DAUSTIN_TOOLCHAIN2",
+                            "-Wno-psabi",
+                            "-Wno-unused-parameter",
+                            "-fPIC",
+                            "-pthread",
+                        ],
                     ),
                 ]),
             ),
@@ -209,6 +243,7 @@ def _impl(ctx):
 
     compiler_param_feature = feature(
         name = "compiler_param_file",
+        enabled = True,
     )
 
     archive_param_file_feature = feature(

--- a/toolchains/cross_compiler/cc-toolchain-config.bzl
+++ b/toolchains/cross_compiler/cc-toolchain-config.bzl
@@ -191,7 +191,6 @@ def _impl(ctx):
                         flags = [
                             "-Wformat=2",
                             "-pedantic",
-                            "-DAUSTIN_TOOLCHAIN",
                             "-Wno-psabi",
                             "-Wno-unused-parameter",
                             "-fPIC",
@@ -210,7 +209,6 @@ def _impl(ctx):
                             "-Wno-deprecated-enum-enum-conversion",
                             "-Wformat=2",
                             "-pedantic",
-                            "-DAUSTIN_TOOLCHAIN2",
                             "-Wno-psabi",
                             "-Wno-unused-parameter",
                             "-fPIC",
@@ -246,6 +244,23 @@ def _impl(ctx):
         enabled = True,
     )
 
+    treat_warnings_as_errors_feature = feature(
+        name = "treat_warnings_as_errors",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                flag_groups = [flag_group(flags = ["-Werror"])],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [flag_group(
+                    flags = ["-Wl,-fatal-warnings"],
+                )],
+            ),
+        ],
+    )
+
     archive_param_file_feature = feature(
         name = "archive_param_file",
         enabled = True,
@@ -278,10 +293,31 @@ def _impl(ctx):
 
     opt_feature = feature(name = "opt")
 
+    set_install_name_feature = feature(
+        name = "set_soname",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Wl,-soname,%{runtime_solib_name}",
+                        ],
+                        expand_if_available = "runtime_solib_name",
+                    ),
+                ],
+            ),
+        ],
+    )
+
     features += [
         unfiltered_compile_flags_feature,
         default_link_flags_feature,
         default_compile_flags_feature,
+        treat_warnings_as_errors_feature,
         sysroot_feature,
         dbg_feature,
         opt_feature,
@@ -290,6 +326,7 @@ def _impl(ctx):
         gcc_quoting_for_param_files_feature,
         static_link_cpp_runtimes_feature,
         archive_param_file_feature,
+        set_install_name_feature,
     ]
 
     return cc_common.create_cc_toolchain_config_info(

--- a/toolchains/cross_compiler/cc-toolchain-config.bzl
+++ b/toolchains/cross_compiler/cc-toolchain-config.bzl
@@ -147,7 +147,6 @@ def _impl(ctx):
                             "-Wall",
                             "-fno-omit-frame-pointer",
                             "-Wextra",
-                            "-Werror",
                         ],
                     ),
                 ]),


### PR DESCRIPTION
Multiarch builds need --copts and such to not be crutial, or be the same on all platforms.  Given we need to support running on Windows, OSX and Linux, those won't work.  Instead, push all those flags into the crosstool.

If we want to be configurable here, we can take arguments in the WORKSPACE file to tweak the crosstool instead.