### PR TITLE
Make aarch64 macs able to cross compile for the RIO

### DIFF
--- a/toolchains/configure_cross_compiler.bzl
+++ b/toolchains/configure_cross_compiler.bzl
@@ -28,7 +28,10 @@ def configure_cross_compiler_impl(repository_ctx):
         substitutions["{arg_passthrough}"] = "%*"
         substitutions["{wrapper_extension}"] = ".bat"
     elif repository_ctx.os.name == "mac os x":
-        substitutions["{compiler_repo}"] = "bazelrio_{}_toolchain_macos".format(repository_ctx.attr.repo_shortname)
+        if repository_ctx.os.arch == "aarch64":
+            substitutions["{compiler_repo}"] = "bazelrio_{}_toolchain_macosarm".format(repository_ctx.attr.repo_shortname)
+        else:
+            substitutions["{compiler_repo}"] = "bazelrio_{}_toolchain_macos".format(repository_ctx.attr.repo_shortname)
     elif repository_ctx.os.name == "linux":
         substitutions["{compiler_repo}"] = "bazelrio_{}_toolchain_linux".format(repository_ctx.attr.repo_shortname)
     else:


### PR DESCRIPTION
We were only picking the systemcore compiler for x86 macs, not the arm one.  Detect and do it right now.