### PR TITLE
Add cc_shared_import to enable importing shared and dynamic libraries

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_bzlmodrio_toolchains",
-    version = "2025-1.bcr4",
+    version = "2025-1.bcr5",
     compatibility_level = 2025,
 )
 

--- a/cc/cc_shared_import.bzl
+++ b/cc/cc_shared_import.bzl
@@ -103,6 +103,7 @@ def cc_shared_import(
         shared_library = shared_library_file,
         hdrs = hdrs,
         includes = includes,
+        visibility = visibility,
         target_compatible_with = target_compatible_with,
     )
 

--- a/cc/cc_shared_import.bzl
+++ b/cc/cc_shared_import.bzl
@@ -1,0 +1,116 @@
+load("@rules_cc//cc:defs.bzl", "cc_import")
+load("@rules_cc//cc/common:cc_shared_library_info.bzl", "CcSharedLibraryInfo")
+
+def _cc_shared_info_adapter_impl(ctx):
+    # With versioned symbols, we can't directly build the CcInfo and linker
+    # inputs ourselves.  Starlark complains about bad extensions.
+    #
+    # So, use cc_import to build up both the shared and static versions, and
+    # pass on the correct one as needed from this rule.
+    static_dep = ctx.attr.static_dep
+    static_dep_cc_info = static_dep[CcInfo]
+
+    dynamic_dep = ctx.attr.dynamic_dep
+    dynamic_dep_cc_info = dynamic_dep[CcInfo]
+
+    linker_inputs = dynamic_dep_cc_info.linking_context.linker_inputs.to_list()
+    if not linker_inputs:
+        fail("No linker inputs found in the dependency.")
+
+    if len(linker_inputs) != 1:
+        fail("Too many linker inputs found in the dependency.")
+
+    shared_linker_input = linker_inputs[0]
+
+    # Create the CcSharedLibraryInfo provider.
+    cc_shared_library_info = CcSharedLibraryInfo(
+        linker_input = shared_linker_input,
+        # Declare that this shared library exports the symbols of the cc_import target which contains the original static library.
+        exports = [str(static_dep.label)],
+        dynamic_deps = depset(),
+        link_once_static_libs = [str(static_dep.label)],
+    )
+
+    runfiles = ctx.runfiles().merge(dynamic_dep[DefaultInfo].default_runfiles)
+
+    return [
+        DefaultInfo(
+            files = runfiles.files,
+            runfiles = runfiles,
+        ),
+        cc_shared_library_info,
+    ]
+
+_cc_shared_info_adapter = rule(
+    implementation = _cc_shared_info_adapter_impl,
+    attrs = {
+        "static_dep": attr.label(
+            doc = "The cc_import target to adapt.",
+            providers = [CcInfo, DefaultInfo],
+            mandatory = True,
+        ),
+        "dynamic_dep": attr.label(
+            doc = "The cc_import target to adapt.",
+            providers = [CcInfo, DefaultInfo],
+            mandatory = True,
+        ),
+    },
+)
+
+def cc_shared_import(
+        name,
+        shared_library_file,
+        static_library_file,
+        hdrs = None,
+        includes = None,
+        visibility = None,
+        target_compatible_with = None):
+    """Imports a prebuilt static and shared library such that Bazel will consume it correctly.
+
+    Args:
+      shared_library_file: The prebuilt file for the shared library.
+      static_library_file: The prebuilt file for the static library.
+      hdrs: The headers to export
+    """
+    interface_library = None
+    if shared_library_file.endswith(".dll"):
+        interface_library = shared_library_file[:-4] + ".lib"
+
+    # Create a single cc_import with both static and shared libraries, and headers.
+    # This target serves as the entry point for static linking.
+    # The shared libraries get used in cc_test linking, and the static ones get
+    # used for linking cc_binary targets.
+    # TODO(austin): pdb files.
+    cc_import(
+        name = name,
+        static_library = static_library_file,
+        interface_library = interface_library,
+        shared_library = shared_library_file,
+        hdrs = hdrs,
+        includes = includes,
+        visibility = visibility,
+        target_compatible_with = target_compatible_with,
+    )
+
+    shared_import_name = name + "_shared_import"
+
+    # Now, create the link options for dynamic only linking to be used by the
+    # shared library adapter.
+    cc_import(
+        name = shared_import_name,
+        interface_library = interface_library,
+        shared_library = shared_library_file,
+        hdrs = hdrs,
+        includes = includes,
+        target_compatible_with = target_compatible_with,
+    )
+
+    # Merge the two as expected.
+    shared_target_name = name + "_shared"
+    _cc_shared_info_adapter(
+        name = shared_target_name,
+        static_dep = ":" + name,
+        dynamic_dep = ":" + shared_import_name,
+        visibility = visibility,
+        target_compatible_with = target_compatible_with,
+    )

--- a/cc/cc_shared_import.bzl
+++ b/cc/cc_shared_import.bzl
@@ -73,6 +73,10 @@ def cc_shared_import(
       static_library_file: The prebuilt file for the static library.
       hdrs: The headers to export
     """
+    # Windows has both DLLs, and interface libraries used to link those DLLs.
+    # Do the stupid thing and detect if we are on Windows by looking for .dll,
+    # and if so, assume there will be an interface library sitting next to it.
+    # Interface libraries don't make sense on OSX or Windows.
     interface_library = None
     if shared_library_file.endswith(".dll"):
         interface_library = shared_library_file[:-4] + ".lib"

--- a/cc/cc_shared_import.bzl
+++ b/cc/cc_shared_import.bzl
@@ -73,6 +73,7 @@ def cc_shared_import(
       static_library_file: The prebuilt file for the static library.
       hdrs: The headers to export
     """
+
     # Windows has both DLLs, and interface libraries used to link those DLLs.
     # Do the stupid thing and detect if we are on Windows by looking for .dll,
     # and if so, assume there will be an interface library sitting next to it.

--- a/cc/cc_shared_import.bzl
+++ b/cc/cc_shared_import.bzl
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_import")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_cc//cc/common:cc_shared_library_info.bzl", "CcSharedLibraryInfo")
 
 def _cc_shared_info_adapter_impl(ctx):
@@ -44,13 +45,13 @@ def _cc_shared_info_adapter_impl(ctx):
 _cc_shared_info_adapter = rule(
     implementation = _cc_shared_info_adapter_impl,
     attrs = {
-        "static_dep": attr.label(
-            doc = "The cc_import target to adapt.",
+        "dynamic_dep": attr.label(
+            doc = "The cc_import target to use for dynamic linking.",
             providers = [CcInfo, DefaultInfo],
             mandatory = True,
         ),
-        "dynamic_dep": attr.label(
-            doc = "The cc_import target to adapt.",
+        "static_dep": attr.label(
+            doc = "The cc_import target to use for normal linking.",
             providers = [CcInfo, DefaultInfo],
             mandatory = True,
         ),


### PR DESCRIPTION
This lets us interoperate with cc_library and cc_shared_library correctly with prebuilt libraries.