### PR TITLE
Set OS and compiler constraints

### DIFF
--- a/platforms/bookworm32/BUILD.bazel
+++ b/platforms/bookworm32/BUILD.bazel
@@ -3,6 +3,7 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:armv7",
+        "@bazel_tools//tools/cpp:gcc",
         "//constraints/is_bookworm32:true",
     ],
     visibility = ["//visibility:public"],

--- a/platforms/bookworm64/BUILD.bazel
+++ b/platforms/bookworm64/BUILD.bazel
@@ -3,6 +3,7 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:arm64",
+        "@bazel_tools//tools/cpp:gcc",
         "//constraints/is_bookworm64:true",
     ],
     visibility = ["//visibility:public"],

--- a/platforms/raspibookworm32/BUILD.bazel
+++ b/platforms/raspibookworm32/BUILD.bazel
@@ -3,6 +3,7 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:armv7",
+        "@bazel_tools//tools/cpp:gcc",
         "//constraints/is_raspibookworm32:true",
     ],
     visibility = ["//visibility:public"],

--- a/platforms/roborio/BUILD.bazel
+++ b/platforms/roborio/BUILD.bazel
@@ -3,6 +3,7 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:armv7",
+        "@bazel_tools//tools/cpp:gcc",
         "//constraints/is_roborio:true",
     ],
     visibility = ["//visibility:public"],

--- a/platforms/systemcore/BUILD.bazel
+++ b/platforms/systemcore/BUILD.bazel
@@ -3,6 +3,7 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:arm64",
+        "@bazel_tools//tools/cpp:gcc",
         "//constraints/is_systemcore:true",
     ],
     visibility = ["//visibility:public"],

--- a/toolchains/cross_compiler/BUILD.tpl
+++ b/toolchains/cross_compiler/BUILD.tpl
@@ -57,6 +57,7 @@ toolchain(
         "@platforms//os:windows",
     ],
     target_compatible_with = [
+        "@platforms//os:linux",
         "@bazel_tools//tools/cpp:gcc",
         "@rules_bzlmodrio_toolchains//constraints/is_{repo_short_name_no_dash}:true",
     ],
@@ -71,6 +72,7 @@ toolchain(
         "@platforms//os:linux",
     ],
     target_compatible_with = [
+        "@platforms//os:linux",
         "@bazel_tools//tools/cpp:gcc",
         "@rules_bzlmodrio_toolchains//constraints/is_{repo_short_name_no_dash}:true",
     ],
@@ -85,6 +87,7 @@ toolchain(
         "@platforms//os:osx",
     ],
     target_compatible_with = [
+        "@platforms//os:linux",
         "@bazel_tools//tools/cpp:gcc",
         "@rules_bzlmodrio_toolchains//constraints/is_{repo_short_name_no_dash}:true",
     ],

--- a/toolchains/cross_compiler/BUILD.tpl
+++ b/toolchains/cross_compiler/BUILD.tpl
@@ -56,7 +56,10 @@ toolchain(
         "@platforms//cpu:x86_64",
         "@platforms//os:windows",
     ],
-    target_compatible_with = ["@rules_bzlmodrio_toolchains//constraints/is_{repo_short_name_no_dash}:true"],
+    target_compatible_with = [
+        "@bazel_tools//tools/cpp:gcc",
+        "@rules_bzlmodrio_toolchains//constraints/is_{repo_short_name_no_dash}:true",
+    ],
     toolchain = cc_toolchain_name,
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
@@ -67,7 +70,10 @@ toolchain(
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
-    target_compatible_with = ["@rules_bzlmodrio_toolchains//constraints/is_{repo_short_name_no_dash}:true"],
+    target_compatible_with = [
+        "@bazel_tools//tools/cpp:gcc",
+        "@rules_bzlmodrio_toolchains//constraints/is_{repo_short_name_no_dash}:true",
+    ],
     toolchain = cc_toolchain_name,
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
@@ -78,7 +84,10 @@ toolchain(
         # assuming x86/ARM Macs use the same x86 WPILib toolchain
         "@platforms//os:osx",
     ],
-    target_compatible_with = ["@rules_bzlmodrio_toolchains//constraints/is_{repo_short_name_no_dash}:true"],
+    target_compatible_with = [
+        "@bazel_tools//tools/cpp:gcc",
+        "@rules_bzlmodrio_toolchains//constraints/is_{repo_short_name_no_dash}:true",
+    ],
     toolchain = cc_toolchain_name,
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )


### PR DESCRIPTION
This sets `rules_cc`'s `compiler_flag` to gcc for the cross-compiler platforms, to allow for easily `select`ing gcc targets (e.g. to specify compiler flags) downstream.

Example usage:

```starlark
cc_library(
    # ...
    copts = select({
        "@bazel_tools//tools/cpp:msvc": [
            "/wd4005",
            "/wd4018",
            "/wd4244",
            "/wd4267",
            "/wd4996",
        ],
        "@bazel_tools//tools/cpp:gcc": [
            "-Wno-format-nonliteral",
            "-Wno-maybe-uninitialized",
            "-Wno-sign-compare",
            "-Wno-type-limits",
        ],
        "//conditions:default": [],
    }),
)
```

Also add the OS and compiler constraints to the cross-compilers, since that was also simple to do, to doubly-ensure nobody's trying to request contradictory compilers. (Adding the CPU constraint was too much for my 2am brain.)