### PR TITLE
Update version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_bzlmodrio_toolchains",
-    version = "2025-1.bcr7",
+    version = "2025-2",
     compatibility_level = 2025,
 )
 


### PR DESCRIPTION
Technically I missed that 2025-1.bcr7 had updated the underlying maven version to 2025-2, but we can treat this like its the first one